### PR TITLE
Add include and exclude attacks to the Extensions UI

### DIFF
--- a/src/main/java/ai/mindgard/MindgardSettings.java
+++ b/src/main/java/ai/mindgard/MindgardSettings.java
@@ -17,7 +17,11 @@ public interface MindgardSettings {
 
     String customDatasetFilename();
 
-    record Settings(String selector, String testName, String dataset, String systemPrompt, String customDatasetFilename) implements MindgardSettings {}
+    String exclude();
+
+    String include();
+
+    record Settings(String selector, String testName, String dataset, String systemPrompt, String customDatasetFilename, String exclude, String include) implements MindgardSettings {}
 
     static File file(String name) {
         String directory = System.getProperty("user.home") + File.separator + ".mindgard";
@@ -27,7 +31,7 @@ public interface MindgardSettings {
 
     default void save() {
         try {
-            Files.write(MindgardSettings.file("burp.json").toPath(), of(JSON.json(new Settings(selector(), testName(), dataset(), systemPrompt(), customDatasetFilename()))));
+            Files.write(MindgardSettings.file("burp.json").toPath(), of(JSON.json(new Settings(selector(), testName(), dataset(), systemPrompt(), customDatasetFilename(), exclude(), include()))));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/ai/mindgard/MindgardSettingsUI.java
+++ b/src/main/java/ai/mindgard/MindgardSettingsUI.java
@@ -19,6 +19,8 @@ public class MindgardSettingsUI extends JPanel implements MindgardSettings {
     private String testName = "burp-suite-test";
     private String dataset = null;
     private String systemPrompt = "Please answer the question: ";
+    private String exclude;
+    private String include;
 
     public MindgardSettingsUI() {
         super(new SpringLayout());
@@ -30,6 +32,8 @@ public class MindgardSettingsUI extends JPanel implements MindgardSettings {
             dataset = Optional.ofNullable(settings.dataset()).orElse(dataset);
             systemPrompt = Optional.ofNullable(settings.systemPrompt()).orElse(systemPrompt);
             customDataset = Optional.ofNullable(settings.customDatasetFilename()).map(File::new).orElse(customDataset);
+            exclude = Optional.ofNullable(settings.exclude()).orElse(exclude);
+            include = Optional.ofNullable(settings.include()).orElse(include);
         } catch (IOException e) {
 
         }
@@ -147,6 +151,31 @@ public class MindgardSettingsUI extends JPanel implements MindgardSettings {
 
         datasetButtons.add(clearButton, constraints);
         inputPanel.add(datasetButtons,gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy = 6;
+        gbc.weightx = 0;
+        JLabel excludeAttacksLabel = new JLabel("Exclude attack(s):");
+        inputPanel.add(excludeAttacksLabel, gbc);
+
+        gbc.gridx = 1;
+        gbc.gridy = 6;
+        gbc.weightx = 1.0;
+        JTextField excludeAttacksField = new JTextField(exclude, 20);
+        inputPanel.add(excludeAttacksField, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy = 7;
+        gbc.weightx = 0;
+        JLabel includeAttacksLabel = new JLabel("Include attack(s):");
+        inputPanel.add(includeAttacksLabel, gbc);
+
+        gbc.gridx = 1;
+        gbc.gridy = 7;
+        gbc.weightx = 1.0;
+        JTextField includeAttacksField = new JTextField(include, 20);
+        inputPanel.add(includeAttacksField, gbc);
+
         gbc.gridx = 3;
         gbc.gridy = 5;
         gbc.weightx = 1.0;
@@ -158,6 +187,8 @@ public class MindgardSettingsUI extends JPanel implements MindgardSettings {
             systemPrompt = systemPromptField.getText();
             dataset = ((Dataset)datasetField.getSelectedItem()).getDatasetName();
             customDataset = customDatasetField.getSelectedFile();
+            exclude = excludeAttacksField.getText();
+            include =includeAttacksField.getText();
 
             save();
         });
@@ -192,5 +223,15 @@ public class MindgardSettingsUI extends JPanel implements MindgardSettings {
     @Override
     public String customDatasetFilename() {
         return Optional.ofNullable(customDataset).map(File::getAbsolutePath).orElse(null);
+    }
+
+    @Override
+    public String exclude() {
+        return exclude;
+    }
+
+    @Override
+    public String include() {
+        return include;
     }
 }

--- a/src/main/java/ai/mindgard/sandbox/wsapi/SandboxConnectionFactory.java
+++ b/src/main/java/ai/mindgard/sandbox/wsapi/SandboxConnectionFactory.java
@@ -13,7 +13,9 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -64,6 +66,14 @@ public class SandboxConnectionFactory {
             super(errors.stream().map(CliInitResponse.Error::message).collect(Collectors.joining()));
         }
     }
+
+    private List<String> commaSeperatedToList(String includedOrExcluded) {
+        if (includedOrExcluded != null && includedOrExcluded.length() > 0) {
+            return Arrays.asList(includedOrExcluded.split(","));
+        }
+        return null;
+    } 
+
     private CliInitResponse cliInit(String target, String accessToken, MindgardSettings settings, Log logger) {
         try {
             var params = new OrchestratorSetupRequest(
@@ -75,7 +85,9 @@ public class SandboxConnectionFactory {
                     "llm",
                     "user",
                     "sandbox",
-                    null
+                    null,
+                    commaSeperatedToList(settings.exclude()),
+                    commaSeperatedToList(settings.include())
             );
 
             var cliInit = HttpRequest.newBuilder()

--- a/src/main/java/ai/mindgard/sandbox/wsapi/messages/OrchestratorSetupRequest.java
+++ b/src/main/java/ai/mindgard/sandbox/wsapi/messages/OrchestratorSetupRequest.java
@@ -1,4 +1,5 @@
 package ai.mindgard.sandbox.wsapi.messages;
+import java.util.List;
 
 public record OrchestratorSetupRequest(
     String target,
@@ -9,5 +10,7 @@ public record OrchestratorSetupRequest(
     String modelType,
     String attackSource,
     String attackPack,
-    Object labels
+    Object labels,
+    List<String> exclude,
+    List<String> include
 ) {}


### PR DESCRIPTION
* The UI captures a comma separated string for including and excluding attacks
* The OrchestratorSetupRequest is populated with the include and exclude attacks flags
* This helps with running subsets of attacks via Burp Suite