### PR TITLE
wording change on extension config save dialog for clarity

### DIFF
--- a/src/main/java/ai/mindgard/MindgardSettingsUI.java
+++ b/src/main/java/ai/mindgard/MindgardSettingsUI.java
@@ -324,7 +324,7 @@ public class MindgardSettingsUI extends JPanel implements MindgardSettings {
                     this,
                     "Mindgard settings updated successfully!" + "\n" +
                             "Tests run using this configuration can be found at https://sandbox.mindgard.ai/results" + "\n" +
-                            "with the model name: " + testName,
+                            "with the target name: " + testName,
                     "Mindgard Extension",
                     JOptionPane.INFORMATION_MESSAGE
             );

--- a/src/main/java/ai/mindgard/MindgardSettingsUI.java
+++ b/src/main/java/ai/mindgard/MindgardSettingsUI.java
@@ -323,7 +323,7 @@ public class MindgardSettingsUI extends JPanel implements MindgardSettings {
             JOptionPane.showMessageDialog(
                     this,
                     "Mindgard settings updated successfully!" + "\n" +
-                            "You can view the result of your test at https://sandbox.mindgard.ai/models-assessment" + "\n" +
+                            "Tests run using this configuration can be found at https://sandbox.mindgard.ai/results" + "\n" +
                             "with the model name: " + testName,
                     "Mindgard Extension",
                     JOptionPane.INFORMATION_MESSAGE


### PR DESCRIPTION
- When saving your mg extension config, the dialog says "you can view the result of your test at <>", which to me implies that clicking save ran a test, or is in the least is ambiguous.

- URL out of date