### PR TITLE
Extracting a Mindgard interface for probes

### DIFF
--- a/src/main/java/ai/mindgard/MindgardExtension.java
+++ b/src/main/java/ai/mindgard/MindgardExtension.java
@@ -2,10 +2,13 @@ package ai.mindgard;
 
 import ai.mindgard.burp.generators.GeneratorFactory;
 import ai.mindgard.sandbox.Mindgard;
+import ai.mindgard.sandbox.MindgardWebSocketPrompts;
 import ai.mindgard.burp.generators.MindgardGenerator;
 import ai.mindgard.burp.MindgardHttpHandler;
 import burp.api.montoya.BurpExtension;
 import burp.api.montoya.MontoyaApi;
+
+import java.time.Instant;
 
 public class MindgardExtension implements BurpExtension {
     @Override
@@ -14,7 +17,7 @@ public class MindgardExtension implements BurpExtension {
         MindgardSettingsUI settings = new MindgardSettingsUI();
         Log logger = api.logging()::logToOutput;
         var auth = new MindgardAuthentication(logger);
-        Mindgard mg = new Mindgard(logger, auth, settings);
+        Mindgard mg = new MindgardWebSocketPrompts(logger, auth, settings, 60L);
 
         try {
             auth.auth();
@@ -28,7 +31,7 @@ public class MindgardExtension implements BurpExtension {
 
         api.userInterface().registerSuiteTab("Mindgard", settings);
 
-        api.logging().logToOutput("Loaded Mindgard Generators");
+        api.logging().logToOutput("["+ Instant.now() + "] Loaded Mindgard Generators");
     }
 
 }

--- a/src/main/java/ai/mindgard/burp/generators/MindgardGenerator.java
+++ b/src/main/java/ai/mindgard/burp/generators/MindgardGenerator.java
@@ -6,12 +6,14 @@ import burp.api.montoya.intruder.GeneratedPayload;
 import burp.api.montoya.intruder.IntruderInsertionPoint;
 import burp.api.montoya.intruder.PayloadGenerator;
 
+import java.time.Instant;
+
 public class MindgardGenerator implements PayloadGenerator {
     private final Mindgard mindgard;
     private final Log logger;
 
     public MindgardGenerator(Mindgard mindgard, Log logger) {
-        logger.log("Loading Generator");
+        logger.log("["+ Instant.now() + "] Loading Generator");
         mindgard.reset();
         this.mindgard = mindgard;
         this.logger = logger;
@@ -32,7 +34,7 @@ public class MindgardGenerator implements PayloadGenerator {
     }
 
     private GeneratedPayload end() {
-        logger.log("END");
+        logger.log("["+ Instant.now() + "] END");
         mindgard.reset();
         return GeneratedPayload.end();
     }

--- a/src/main/java/ai/mindgard/sandbox/Mindgard.java
+++ b/src/main/java/ai/mindgard/sandbox/Mindgard.java
@@ -1,96 +1,20 @@
 package ai.mindgard.sandbox;
 
-import ai.mindgard.Log;
-import ai.mindgard.MindgardAuthentication;
-import ai.mindgard.MindgardSettings;
-import ai.mindgard.sandbox.wsapi.SandboxConnection;
-import ai.mindgard.sandbox.wsapi.SandboxConnectionFactory;
-
-import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
-public class Mindgard {
-    private final Log logger;
-    private final MindgardAuthentication auth;
-    private MindgardSettings settings;
-    private final Supplier<SandboxConnectionFactory> connectionFactory;
-    private BlockingDeque<Probe> newProbes = new LinkedBlockingDeque<>();
-    private Pending pending = new Pending();
+public interface Mindgard {
+    void startGeneratingProbes();
 
-    private boolean started = false;
-    private boolean doneSomething = false;
-    private SandboxConnection connection;
+    void reset();
 
-    public Mindgard(Log logger, MindgardAuthentication auth, MindgardSettings settings) {
-        this(logger, auth, settings, () -> new SandboxConnectionFactory(HttpClient.newHttpClient()));
-    }
+    Optional<Probe> poll();
 
-    public Mindgard(Log logger, MindgardAuthentication auth, MindgardSettings settings, Supplier<SandboxConnectionFactory> connectionFactory) {
-        this.logger = logger;
-        this.auth = auth;
-        this.settings = settings;
-        this.connectionFactory = connectionFactory;
-    }
+    Probe reply(String correlationId, String reply);
 
-    public void startGeneratingProbes(){
-        this.started = true;
-        this.connection = connectionFactory.get().connect(this, auth, settings,logger);
-    }
+    List<Probe> pendingProbes();
 
-    public void reset() {
-        started = false;
-        newProbes = new LinkedBlockingDeque<>();
-        doneSomething = false;
-        pending = new Pending();
-    }
+    boolean isStarted();
 
-    public Optional<Probe> poll() {
-        return poll(60L);
-    }
-
-    public Optional<Probe> poll(Long timeoutSeconds) {
-        try {
-            return Optional.ofNullable(pending(newProbes.poll(timeoutSeconds, TimeUnit.SECONDS)));
-        } catch (InterruptedException e) {
-            return Optional.empty();
-        }
-    }
-
-    private Probe pending(Probe popped) {
-        if (popped != null) {
-            pending.add(popped);
-        }
-        return popped;
-    }
-
-    public Probe reply(String correlationId, String reply) {
-        Probe probe = pending.get(correlationId);
-        pending.clear(correlationId);
-        if (this.connection != null) {
-            this.connection.reply(correlationId, reply);
-        }
-        return probe;
-    }
-
-    public boolean hasMoreProbes() {
-        return !doneSomething || !newProbes.isEmpty();
-    }
-
-    public List<Probe> pendingProbes() {
-        return pending.list();
-    }
-
-    public boolean isStarted() {
-        return started;
-    }
-
-    public void push(Probe probe) {
-        newProbes.push(probe);
-        this.doneSomething = true;
-    }
+    void push(Probe probe);
 }

--- a/src/main/java/ai/mindgard/sandbox/MindgardWebSocketPrompts.java
+++ b/src/main/java/ai/mindgard/sandbox/MindgardWebSocketPrompts.java
@@ -1,0 +1,100 @@
+package ai.mindgard.sandbox;
+
+import ai.mindgard.Log;
+import ai.mindgard.MindgardAuthentication;
+import ai.mindgard.MindgardSettings;
+import ai.mindgard.sandbox.wsapi.SandboxConnection;
+import ai.mindgard.sandbox.wsapi.SandboxConnectionFactory;
+
+import java.net.http.HttpClient;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class MindgardWebSocketPrompts implements Mindgard {
+    private final Log logger;
+    private final MindgardAuthentication auth;
+    private final MindgardSettings settings;
+    private final Supplier<SandboxConnectionFactory> connectionFactory;
+    private BlockingDeque<Probe> newProbes = new LinkedBlockingDeque<>();
+    private Pending pending = new Pending();
+
+    private boolean started = false;
+    private SandboxConnection connection;
+    private final long pollTimeout;
+
+    public MindgardWebSocketPrompts(Log logger, MindgardAuthentication auth, MindgardSettings settings, long pollTimeoutSeconds) {
+        this(logger, auth, settings, pollTimeoutSeconds, () -> new SandboxConnectionFactory(HttpClient.newHttpClient()));
+    }
+
+    public MindgardWebSocketPrompts(Log logger, MindgardAuthentication auth, MindgardSettings settings, long pollTimeoutSeconds, Supplier<SandboxConnectionFactory> connectionFactory) {
+        this.logger = logger;
+        this.auth = auth;
+        this.settings = settings;
+        this.connectionFactory = connectionFactory;
+        this.pollTimeout = pollTimeoutSeconds;
+    }
+
+    @Override
+    public void startGeneratingProbes(){
+        this.started = true;
+        this.connection = connectionFactory.get().connect(this, auth, settings,logger);
+        logger.log("["+ Instant.now() + "] [ws] Starting probe generation");
+    }
+
+    @Override
+    public void reset() {
+        started = false;
+        newProbes = new LinkedBlockingDeque<>();
+        pending = new Pending();
+    }
+
+    @Override
+    public Optional<Probe> poll() {
+        return poll(pollTimeout);
+    }
+
+    private Optional<Probe> poll(Long timeoutSeconds) {
+        try {
+            return Optional.ofNullable(pending(newProbes.poll(timeoutSeconds, TimeUnit.SECONDS)));
+        } catch (InterruptedException e) {
+            return Optional.empty();
+        }
+    }
+
+    private Probe pending(Probe popped) {
+        if (popped != null) {
+            pending.add(popped);
+        }
+        return popped;
+    }
+
+    @Override
+    public Probe reply(String correlationId, String reply) {
+        Probe probe = pending.get(correlationId);
+        pending.clear(correlationId);
+        if (this.connection != null) {
+            this.connection.reply(correlationId, reply);
+        }
+        return probe;
+    }
+
+    @Override
+    public List<Probe> pendingProbes() {
+        return pending.list();
+    }
+
+    @Override
+    public boolean isStarted() {
+        return started;
+    }
+
+    @Override
+    public void push(Probe probe) {
+        newProbes.push(probe);
+    }
+}


### PR DESCRIPTION
* This allows for implementing different protocols for probes that is supported by Mindgard.
* The hasMoreProbes() is removed as it was only used in tests and not supporting the behaviour of the extension.
* The poll timeout is now configurable so that we don't need to expose additional methods for testing purposes.
* This changeset also includes some usability improvements around diagnosing any problems that might occur in using the extension (showing timestamps on when important actions occur)