### PR TITLE
Trailing slash causing a service not found 400 error.

### DIFF
--- a/src/main/java/ai/mindgard/Constants.java
+++ b/src/main/java/ai/mindgard/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
     public static final String SETTINGS_FILE_NAME = "burp.json";
     public static final String TOKEN_FILE_NAME = "token.json";
     public static final String CLIENT_ID = "mBSDAk4R283BeGC17Uvbyo3vSAAGL67J";
-    public static final String AUDIENCE = "https://prod-pov-demo-orchestrator.com/";
+    public static final String AUDIENCE = "https://prod-pov-demo-orchestrator.com";
     public static final String LOGIN_DOMAIN = "https://login.demo.us.mindgard.ai";
 
     private Constants() {}


### PR DESCRIPTION
* This has been removed from the default audience constant.