### PR TITLE
Auth error debug improvements

### DIFF
--- a/src/main/java/ai/mindgard/DeviceCodeFlow.java
+++ b/src/main/java/ai/mindgard/DeviceCodeFlow.java
@@ -58,7 +58,7 @@ public class DeviceCodeFlow {
     }
 
     public record DeviceCodePayload(String client_id, String scope, String audience){}
-    public record DeviceCodeData(String verification_uri, String verification_uri_complete, String user_code, String device_code, String expires_in, String interval) {}
+    public record DeviceCodeData(String verification_uri, String verification_uri_complete, String user_code, String device_code, String expires_in, String interval, String error, String error_description) {}
 
     public DeviceCodeData getDeviceCode() {;
         var settings = mgsm.getSettings();
@@ -72,7 +72,15 @@ public class DeviceCodeFlow {
                 .build();
         try {
             var response = http.send(request, HttpResponse.BodyHandlers.ofString());
-            return fromJson(response.body(), DeviceCodeData.class);
+            var data = fromJson(response.body(), DeviceCodeData.class);
+            if (response.statusCode() >= 400 || data.error() != null) {
+                throw new LoginException(
+                    "Failed to get device code: " + data.error()
+                    + " - " + data.error_description() + " - response status: " + response.statusCode());
+            }
+            return data;
+        } catch (LoginException e) {
+            throw e;
         } catch (Exception e) {
             throw new LoginException("Failed to get device code", e);
         }

--- a/src/main/java/ai/mindgard/DeviceCodeFlow.java
+++ b/src/main/java/ai/mindgard/DeviceCodeFlow.java
@@ -22,14 +22,16 @@ public class DeviceCodeFlow {
     private final HttpClient http;
     private final Function<String, HttpRequest.BodyPublisher> publisher;
     private MindgardSettingsManager mgsm;
+    private Log logger;
 
     public interface Factory {
-        DeviceCodeFlow create(HttpClient http, Function<String,HttpRequest.BodyPublisher> publisher, MindgardSettingsManager mgsm);
+        DeviceCodeFlow create(HttpClient http, Function<String,HttpRequest.BodyPublisher> publisher, MindgardSettingsManager mgsm, Log logger);
     }
-    public DeviceCodeFlow(HttpClient http, Function<String,HttpRequest.BodyPublisher> publisher, MindgardSettingsManager mgsm) {
+    public DeviceCodeFlow(HttpClient http, Function<String,HttpRequest.BodyPublisher> publisher, MindgardSettingsManager mgsm, Log logger) {
         this.http = http;
         this.publisher = publisher;
         this.mgsm = mgsm;
+        this.logger = logger;
     }
 
     public void validateIdToken(String idToken) {
@@ -106,10 +108,13 @@ public class DeviceCodeFlow {
                 .build();
         try {
             var response = http.send(request, HttpResponse.BodyHandlers.ofString());
-            return response.statusCode() >= 400
-                    ? Optional.empty()
-                    : Optional.of(fromJson(response.body(), TokenData.class));
+            if (response.statusCode() >= 400) {
+                logger.log("Token request failed with status " + response.statusCode() + ": " + response.body());
+                return Optional.empty();
+            }
+            return Optional.of(fromJson(response.body(), TokenData.class));
         } catch (Exception e) {
+            logger.log("Token request error: " + e.getMessage());
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/ai/mindgard/LoginTab.java
+++ b/src/main/java/ai/mindgard/LoginTab.java
@@ -86,7 +86,7 @@ public class LoginTab extends JPanel {
                     });
                     timeoutThread.start();
                     try {
-                        var auth = new MindgardAuthentication(mgsm);
+                        var auth = new MindgardAuthentication(mgsm, logger);
                         logger.log("Attempting to authenticate...");
                         var deviceCode = auth.get_device_code();
 

--- a/src/main/java/ai/mindgard/MindgardAuthentication.java
+++ b/src/main/java/ai/mindgard/MindgardAuthentication.java
@@ -27,26 +27,23 @@ public class MindgardAuthentication {
     private final DeviceCodeFlow deviceCodeFlow;
     private MindgardSettingsManager mgsm;
 
-    /**
-     * Constructor
-     * @param settings The Mindgard Settings record
-     */
-    public MindgardAuthentication(MindgardSettingsManager mgsm) {
+    public MindgardAuthentication(MindgardSettingsManager mgsm, Log logger) {
         this(
             mgsm,
-            HttpClient.newHttpClient(), 
-            HttpRequest.BodyPublishers::ofString, 
-            DeviceCodeFlow::new, 
-            MindgardAuthentication::sleep
+            HttpClient.newHttpClient(),
+            HttpRequest.BodyPublishers::ofString,
+            DeviceCodeFlow::new,
+            MindgardAuthentication::sleep,
+            logger
         );
     }
 
-    public MindgardAuthentication(MindgardSettingsManager mgsm, HttpClient http, Function<String,HttpRequest.BodyPublisher> bodyPublisherFactory, DeviceCodeFlow.Factory deviceCodeFlow, Runnable sleep) {
+    public MindgardAuthentication(MindgardSettingsManager mgsm, HttpClient http, Function<String,HttpRequest.BodyPublisher> bodyPublisherFactory, DeviceCodeFlow.Factory deviceCodeFlow, Runnable sleep, Log logger) {
         this.mgsm = mgsm;
         this.http = http;
         this.publisher = bodyPublisherFactory;
         this.sleep = sleep;
-        this.deviceCodeFlow = deviceCodeFlow.create(http, publisher, mgsm);
+        this.deviceCodeFlow = deviceCodeFlow.create(http, publisher, mgsm, logger);
     }
 
     /**

--- a/src/main/java/ai/mindgard/MindgardExtension.java
+++ b/src/main/java/ai/mindgard/MindgardExtension.java
@@ -17,7 +17,7 @@ public class MindgardExtension implements BurpExtension {
         Log logger = api.logging()::logToOutput;
         MindgardSettingsManager mgsm = new MindgardSettingsManager();
         MindgardSettingsUI userInterface = new MindgardSettingsUI(mgsm, logger);
-        var auth = new MindgardAuthentication(mgsm);
+        var auth = new MindgardAuthentication(mgsm, logger);
         Mindgard mg = new MindgardWebSocketPrompts(logger, auth, mgsm, 60L);
 
         api.intruder().registerPayloadGeneratorProvider(new GeneratorFactory<>(MindgardGenerator.class, () -> new MindgardGenerator(mg, logger)));

--- a/src/test/java/ai/mindgard/DeviceCodeFlowTest.java
+++ b/src/test/java/ai/mindgard/DeviceCodeFlowTest.java
@@ -36,7 +36,7 @@ class DeviceCodeFlowTest {
         when(http.send(any(), any())).thenReturn(response);
         when(response.body()).thenReturn("not-json");
         
-        DeviceCodeFlow dcf = new DeviceCodeFlow(http, matchHttpBody, mgsm);
+        DeviceCodeFlow dcf = new DeviceCodeFlow(http, matchHttpBody, mgsm, msg -> {});
         Exception exception = assertThrows(LoginException.class, dcf::getDeviceCode);
         assertTrue(exception.getMessage().contains("Failed to get device code"));
     }
@@ -59,7 +59,7 @@ class DeviceCodeFlowTest {
 
         var matchHttpBody = mockHttp(json(new DeviceCodePayload(mgsm.getSettings().clientID(), "openid profile email offline_access", mgsm.getSettings().audience())),json(tokenData), publisher, http, response);
 
-        var actual = new DeviceCodeFlow(http, matchHttpBody,mgsm).getDeviceCode();
+        var actual = new DeviceCodeFlow(http, matchHttpBody, mgsm, msg -> {}).getDeviceCode();
 
         assertEquals(tokenData, actual);
     }
@@ -87,7 +87,7 @@ class DeviceCodeFlowTest {
 
         var matchHttpBody = mockHttp(json(tokenPayload), json(tokenData), publisher, http, response);
 
-        var actual = new DeviceCodeFlow(http, matchHttpBody, mgsm).getToken(deviceCodeData);
+        var actual = new DeviceCodeFlow(http, matchHttpBody, mgsm, msg -> {}).getToken(deviceCodeData);
 
         assertEquals(tokenData, actual.get());
     }

--- a/src/test/java/ai/mindgard/DeviceCodeFlowTest.java
+++ b/src/test/java/ai/mindgard/DeviceCodeFlowTest.java
@@ -48,7 +48,7 @@ class DeviceCodeFlowTest {
         var http = mock(HttpClient.class);
         var response = mock(HttpResponse.class);
 
-        var tokenData = new DeviceCodeFlow.DeviceCodeData("verification_uri", "verification_uri_complete","user_code","device_code","expires_in","interval");
+        var tokenData = new DeviceCodeFlow.DeviceCodeData("verification_uri", "verification_uri_complete","user_code","device_code","expires_in","interval", null, null);
         
         var mgsm = mock(MindgardSettingsManager.class);
         var settings = mock(MindgardSettings.class);
@@ -74,7 +74,7 @@ class DeviceCodeFlowTest {
         when(settings.clientID()).thenReturn("mindgard-clientID");
         when(settings.audience()).thenReturn("https://mindgard-audience.com");
 
-        var deviceCodeData = new DeviceCodeFlow.DeviceCodeData("verification_uri", "verification_uri_complete","user_code","device_code","expires_in","interval");
+        var deviceCodeData = new DeviceCodeFlow.DeviceCodeData("verification_uri", "verification_uri_complete","user_code","device_code","expires_in","interval", null, null);
         var tokenPayload = new DeviceCodeFlow.TokenPayload(
                 "urn:ietf:params:oauth:grant-type:device_code",
                 deviceCodeData.device_code(),

--- a/src/test/java/ai/mindgard/MindgardAuthenticationTest.java
+++ b/src/test/java/ai/mindgard/MindgardAuthenticationTest.java
@@ -40,7 +40,7 @@ class MindgardAuthenticationTest {
         when(mgsm.getSettings()).thenReturn(settings);
         doReturn(new MindgardToken("https://sandbox.mindgard.ai", "example-token")).when(mgsm).getToken();
 
-        var auth = new MindgardAuthentication(mgsm, http, matchHttpBody, DeviceCodeFlow::new, () -> {});
+        var auth = new MindgardAuthentication(mgsm, http, matchHttpBody, DeviceCodeFlow::new, () -> {}, msg -> {});
 
         when(http.send(argThat(req -> Objects.equals(publisher,req.bodyPublisher().get())), any())).thenReturn(response);
         when(response.body()).thenReturn("{\"access_token\": \"example-access-token\", \"id_token\": \"x\", \"scope\": \"y\", \"expires_in\":\"z\", \"token_type\":\"u\"}");
@@ -65,7 +65,7 @@ class MindgardAuthenticationTest {
         when(mgsm.getSettings()).thenReturn(settings);
         doReturn(new MindgardToken("https://sandbox.mindgard.ai", "")).when(mgsm).getToken();
 
-        var auth = new MindgardAuthentication(mgsm, http, matchHttpBody, DeviceCodeFlow::new, () -> {});
+        var auth = new MindgardAuthentication(mgsm, http, matchHttpBody, DeviceCodeFlow::new, () -> {}, msg -> {});
 
         when(http.send(argThat(req -> Objects.equals(publisher,req.bodyPublisher().get())), any())).thenReturn(response);
         when(response.body()).thenReturn("{\"access_token\": \"example-access-token\", \"id_token\": \"x\", \"scope\": \"y\", \"expires_in\":\"z\", \"token_type\":\"u\"}");
@@ -96,7 +96,7 @@ class MindgardAuthenticationTest {
         when(mgsm.getSettings()).thenReturn(settings);
         doNothing().when(mgsm).setToken(anyString());
 
-        var auth = new MindgardAuthentication(mgsm, http, body -> null,(h,p,m) -> deviceCodeFlow, () -> {});
+        var auth = new MindgardAuthentication(mgsm, http, body -> null, (h,p,m,l) -> deviceCodeFlow, () -> {}, msg -> {});
         auth.validate_login(deviceCode);
         verify(deviceCodeFlow).validateIdToken("id_token");
         verify(mgsm).setToken("refresh_token");

--- a/src/test/java/ai/mindgard/MindgardAuthenticationTest.java
+++ b/src/test/java/ai/mindgard/MindgardAuthenticationTest.java
@@ -79,7 +79,7 @@ class MindgardAuthenticationTest {
     @Test
     public void login() throws IOException, InterruptedException {
         var http = mock(HttpClient.class);
-        DeviceCodeData deviceCode = new DeviceCodeData("http://example.com/login", "http://example.com/login_complete", "user_code", "device_code", "", "");
+        DeviceCodeData deviceCode = new DeviceCodeData("http://example.com/login", "http://example.com/login_complete", "user_code", "device_code", "", "", null, null);
         TokenData tokenData = new TokenData("refresh_token", "id_token", "", "", "", "", "", "");
         var deviceCodeFlow = mock(DeviceCodeFlow.class);
 


### PR DESCRIPTION

[Fix response parsing for device code flow](https://github.com/Mindgard/mindgard-burp-extension/commit/3e1f52e7d023a44b561b8ee3e43fce2095a9c667) 

* Adding `error` and `error_description` for parsing any errors we might get
  as part of the response body. Without this any errors suffer from a parsing
  error.
* Also if the status code communicates an error, we build our own exception
  with the data available and the status code, so that logs will give us clues
  on what happened.

[Better error logging for auth token generation](https://github.com/Mindgard/mindgard-burp-extension/commit/c282cc0cb4084b930122b491dd874c66d5238018) 

* Getting better logging for debugging purposes when acquiring an auth token for a device code.